### PR TITLE
Updated old links to documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -37,8 +37,8 @@ Some of TRAL's functions depend on external software ([Installation instructions
 
 
 
-[documented on GitHub IO]:http://elkeschaper.github.io/tral/
-[Installation instructions]:http://elkeschaper.github.io/tral/install.html#install
-[Installation instructions for dependencies]:http://elkeschaper.github.io/tral/install_external.html#install-external
+[documented on GitHub IO]:https://acg-team.github.io/tral/
+[Installation instructions]:https://acg-team.github.io/tral/install.html#install
+[Installation instructions for dependencies]:https://acg-team.github.io/tral/install_external.html#install-external
 [Pypi]:https://pypi.python.org/pypi
 [pip]:https://pip.pypa.io/en/latest/


### PR DESCRIPTION
Links to documentation are new referring to the github page of the acg-team and no longer to Elke Schaper's profile