### PR TITLE
Add Vagrant support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,10 +74,14 @@ Vagrant.configure("2") do |config|
     apt-get -y install python3 python3-pip unzip
     pip3 install virtualenv
 
+    # reduce wget output during provisioning
+    echo 'verbose = off' >> ~/.wgetrc
+
     cd /vagrant/easy_setup
 
     # accept all licenses
     sed -i 's/ACCEPT_ALL=no/ACCEPT_ALL=yes/i' configTRAL_path.cfg
+
 
     # Install TRAL software
     ./setupTRAL.sh setup

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,9 +68,22 @@ Vagrant.configure("2") do |config|
   #   apt-get install -y apache2
   # SHELL
   config.vm.provision "shell", inline: <<-SHELL
+    # Install dependencies
     apt-get update
     apt-get -y dist-upgrade
     apt-get -y install python3 python3-pip unzip
+    pip3 install virtualenv
+
+    cd /vagrant/easy_setup
+
+    # accept all licenses
+    sed -i 's/ACCEPT_ALL=no/ACCEPT_ALL=yes/i' configTRAL_path.cfg
+
+    # Install TRAL software
+    ./setupTRAL.sh setup
+    echo
+    echo "THIS MACHINE CONTAINS PROPRIETARY SOFTWARE."
+    echo "Please check the licenses before using (e.g. no commercial use permitted)"
   SHELL
   
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,78 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "ubuntu/bionic64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update
+    apt-get -y dist-upgrade
+    apt-get install python3 python3-pip unzip
+    #sudo -u vagrant -i
+    #cd /vagrant/easy_setup/
+  SHELL
+  
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,9 +70,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: <<-SHELL
     apt-get update
     apt-get -y dist-upgrade
-    apt-get install python3 python3-pip unzip
-    #sudo -u vagrant -i
-    #cd /vagrant/easy_setup/
+    apt-get -y install python3 python3-pip unzip
   SHELL
   
 end

--- a/easy_setup/configTRAL_path.cfg
+++ b/easy_setup/configTRAL_path.cfg
@@ -23,7 +23,5 @@ TRAL_ENV=$TRAL_PATH/tral_env        # virtual environment for python3
 
 TRAL_CONF=$HOME/.tral                   # configuration files --> .tral will be created in $HOME
 
-
 PYTHON3=python3
-PIP3=pip
-
+PIP3=pip3


### PR DESCRIPTION
Create a VM with TRAL installed at a single command.

Users are responsible for complying with the licenses of any tools they use.
Most tools are restricted to academic noncommercial use.